### PR TITLE
Adding sort direction option to thenComparing

### DIFF
--- a/comparators.js
+++ b/comparators.js
@@ -40,13 +40,13 @@
         };
 
         var lastStepInComparisonChain = comparatorFunction;
-        comparatorFunction.thenComparing = function(attrOrFunction){
-            lastStepInComparisonChain = lastStepInComparisonChain.nextStep = buildComparisonStep(attrOrFunction);
+        comparatorFunction.thenComparing = function(attrOrFunction, opts){
+            lastStepInComparisonChain = lastStepInComparisonChain.nextStep = buildComparisonStep(attrOrFunction, opts);
             return this;
-        }
+        };
 
         return comparatorFunction;
-    }
+    };
 
     return { comparing: buildComparisonStep };
 }));

--- a/comparators.min.js
+++ b/comparators.min.js
@@ -1,5 +1,5 @@
-/* Comparators.js 1.1.0
+/* Comparators.js 1.0.0
  * http://spencerwi.github.io/Comparators.js
  * (c) 2014 Spencer Williams
  * Comparators.js may be freely distributed under the MIT license. */
-(function(e,n){if(typeof module!="undefined"){module.exports=n()}else if(typeof define=="function"&&typeof define.amd=="object"){define(n)}else{this[e]=n()}})("Comparators",function(){var e=function(n,t){var f=t&&t.reversed;var i=function(e,t){var r,o,u;if(typeof n==="function"){o=n(e);u=n(t)}else{o=e[n];u=t[n]}if(o>u){if(f){r=-1}else{r=1}}else if(o<u){if(f){r=1}else{r=-1}}else{if(i.nextStep!=undefined){r=i.nextStep(e,t)}else{r=0}}return r};var r=i;i.thenComparing=function(n){r=r.nextStep=e(n);return this};return i};return{comparing:e}});
+(function(e,n){if(typeof module!="undefined"){module.exports=n()}else if(typeof define=="function"&&typeof define.amd=="object"){define(n)}else{this[e]=n()}})("Comparators",function(){var e=function(n,t){var f=t&&t.reversed;var i=function(e,t){var r,o,u;if(typeof n==="function"){o=n(e);u=n(t)}else{o=e[n];u=t[n]}if(o>u){if(f){r=-1}else{r=1}}else if(o<u){if(f){r=1}else{r=-1}}else{if(i.nextStep!=undefined){r=i.nextStep(e,t)}else{r=0}}return r};var r=i;i.thenComparing=function(n,t){r=r.nextStep=e(n,t);return this};return i};return{comparing:e}});

--- a/comparators.spec.js
+++ b/comparators.spec.js
@@ -43,7 +43,7 @@ describe("Comparators", function(){
             var beforeSort = [shouldBeSecond, shouldBeFirst, shouldBeThird];
             var actual = beforeSort.sort(comparatorMethod);
             expect(actual).toEqual(expected);
-        })
+        });
 
         // Reversing comparison direction
         // -------------------------------
@@ -108,7 +108,7 @@ describe("Comparators", function(){
             var beforeSort = [shouldBeSecond, shouldBeFirst, shouldBeThird];
             var actual = beforeSort.sort(comparatorMethod);
             expect(actual).toEqual(expected);
-        })
+        });
 
         // Multiple chains
         // ---------------
@@ -122,7 +122,26 @@ describe("Comparators", function(){
             var shouldBeFirst   = {lastName: "A", firstName: "A", age:24},
                 shouldBeSecond  = {lastName: "A", firstName: "A", age:25},
                 shouldBeThird   = {lastName: "A", firstName: "B", age:24},
-                shouldBeFourth  = {lastName: "B", firstName: "A", age:24}
+                shouldBeFourth  = {lastName: "B", firstName: "A", age:24};
+
+            var expected   = [shouldBeFirst, shouldBeSecond, shouldBeThird, shouldBeFourth];
+            var beforeSort = [shouldBeThird, shouldBeFourth, shouldBeSecond, shouldBeFirst];
+            var actual = beforeSort.sort(comparatorMethod);
+            expect(actual).toEqual(expected);
+        });
+
+        // Multiple chains
+        // ---------------
+        it("can chain multiple comparison keys with mixed directions", function(){
+            // Any point in the chain can be sorted in normal or reverse order.
+            var comparatorMethod = Comparators.comparing("lastName")
+                                                .thenComparing("firstName", {reversed: true})
+                                                .thenComparing("age");
+
+            var shouldBeFirst  = {lastName: "A", firstName: "B", age:24},
+                shouldBeSecond = {lastName: "A", firstName: "A", age:24},
+                shouldBeThird  = {lastName: "A", firstName: "A", age:25},
+                shouldBeFourth = {lastName: "B", firstName: "A", age:24};
 
             var expected   = [shouldBeFirst, shouldBeSecond, shouldBeThird, shouldBeFourth];
             var beforeSort = [shouldBeThird, shouldBeFourth, shouldBeSecond, shouldBeFirst];


### PR DESCRIPTION
While attempting to use Comparators on a project, I noticed the reversed sort option was not available on `thenComparing` calls.

This change allows `{ reversed: true }` for chained `thenComparing`, and includes a spec to verify the functionality.
